### PR TITLE
CI: cut redundant runs, test the Julia versions that actually ship

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,14 @@ on:
     branches:
       - main
       - master
+    tags: ['*']
   pull_request:
+
+concurrency:
+  # Cancel superseded runs on a pull request, but never on a branch: the run on
+  # master is what the README badge reads and what records history.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 
 jobs:
   test:
@@ -14,7 +21,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ["1.6", "1.9", "1.10"]
+        # min: the lower bound declared in Project.toml (currently 1.10, which
+        # is also the LTS). 1: the latest stable release. Both track upstream on
+        # their own, so this list does not need editing when Julia moves on.
+        version: ["min", "1"]
 
     steps:
       - name: Checkout
@@ -25,22 +35,37 @@ jobs:
         with:
           version: ${{ matrix.version }}
 
-      - name: Cache artifacts
-        uses: actions/cache@v4
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-julia-artifacts-${{ hashFiles('**/Project.toml') }}
-          restore-keys: ${{ runner.os }}-julia-artifacts-
+      - name: Cache Julia depot
+        uses: julia-actions/cache@v3
 
-      - name: Install dependencies
-        # DEQuadrature is not in General, so it has to come from its URL: the
-        # [sources] entry in Project.toml only works on Julia 1.11+, and this
-        # matrix predates that. ZeroOrigin is in General and needs nothing.
+      - name: Install unregistered dependencies
+        # DEQuadrature is not in General. Julia 1.11+ resolves it from the
+        # [sources] entry in Project.toml; earlier versions ignore that section
+        # and need the URL spelled out. ZeroOrigin is in General, so it needs
+        # nothing either way.
         run: |
-          julia --project=. -e "using Pkg; Pkg.add(PackageSpec(url=\"https://github.com/JuliaReliab/DEQuadrature.jl.git\"))"
+          julia --project=. -e '
+            using Pkg
+            if VERSION < v"1.11"
+                Pkg.add(PackageSpec(url="https://github.com/JuliaReliab/DEQuadrature.jl.git"))
+            end'
 
       - name: Build package
         uses: julia-actions/julia-buildpkg@v1
 
       - name: Run tests
         uses: julia-actions/julia-runtest@v1
+
+      # julia-runtest already collects coverage (its `coverage` input defaults to
+      # true), so only the report and the upload were missing. One job is enough.
+      - name: Process coverage
+        if: matrix.version == '1'
+        uses: julia-actions/julia-processcoverage@v1
+
+      - name: Upload coverage
+        if: matrix.version == '1'
+        uses: codecov/codecov-action@v7
+        with:
+          files: lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,57 @@
+# NMarkov 0.5.0
+
+## Breaking
+
+- **Requires Julia 1.10 or later** (`[compat] julia = "1.10"`, previously
+  `"1.6"`). 1.10 is the current LTS; 1.6–1.9 are no longer supported.
+
+## CI
+
+- The test matrix is now `["min", "1"]` — the lower bound declared in
+  `Project.toml` and the latest stable release, both resolved by
+  `julia-actions/setup-julia`. It was `1.6 / 1.9 / 1.10`, which tested an EOL
+  version (1.9) and **no currently released Julia at all**: 1.11 and 1.12 were
+  never exercised. Two jobs instead of three.
+- Added a `concurrency` group so a new push to a pull request cancels the
+  superseded run. Runs on a branch are never cancelled, so the master run — the
+  one the README badge reads — always completes.
+- Replaced the hand-rolled `actions/cache` step (which cached only
+  `~/.julia/artifacts`) with `julia-actions/cache@v3`, which caches the whole
+  depot.
+- The `DEQuadrature` URL install is now conditional on `VERSION < v"1.11"`:
+  1.11+ resolves it from the `[sources]` entry in `Project.toml`, earlier
+  versions ignore that section.
+- Coverage is now processed and uploaded (`julia-processcoverage` +
+  `codecov-action`) from the latest-stable job. `julia-runtest` was already
+  collecting it; the report was simply discarded. Uploading needs a
+  `CODECOV_TOKEN` repository secret.
+
+## Documentation
+
+Verified every code example in `README.md` against the current API by running
+it. Corrected:
+
+- `stgs(coo)` was documented as working; `stgs`, `stsengs` and `qstgs` accept
+  only `SparseMatrixCSC` and `SparseCSC`. (The transient functions do accept
+  every format.)
+- `tran`'s third and fourth return values were described as one state vector per
+  time point. They are single vectors: the state at the last time point and the
+  cumulative time in each state over the whole interval. Only the first two
+  returns are per time point; `mexpc` gives the per-time-point vectors.
+- The uniformization formula was written `P = I - Q / q`; it is `P = I + Q / q`.
+  With the minus sign the entries fall outside `[0,1]`. Also documented that
+  `q = ufact * max|Q_ii|` with `ufact` defaulting to 1.01, which was omitted.
+- The quasi-stationary power-method example passed the unscaled exit vector to
+  `qstpower`; it takes `xi / q`, and the eigenvalue it returns is scaled to
+  match.
+- `SparseELL` is not a type name; the exported types are `SparseELL1` and
+  `SparseELL2`.
+- Both badges pointed at `okamumu/NMarkov.jl`, which does not exist. The
+  repository is `JuliaReliab/NMarkov.jl`.
+- Dropped the `ZeroOrigin` install line: it is registered in General and
+  resolves on its own. `DEQuadrature` and NMarkov itself are still unregistered
+  and need their URLs.
+
 # NMarkov 0.4.1
 
 Fixes from a full code review of 0.4.0. Behaviour changes are noted explicitly.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project
 
-NMarkov.jl — Julia package for numerical analysis of continuous-time Markov chains (CTMCs): stationary/quasi-stationary distributions, transient rewards, matrix exponentials, and sensitivity analysis. Not registered; depends on two unregistered JuliaReliab packages (`ZeroOrigin`, `DEQuadrature`). `compat` targets Julia 1.6; CI runs 1.6/1.9/1.10.
+NMarkov.jl — Julia package for numerical analysis of continuous-time Markov chains (CTMCs): stationary/quasi-stationary distributions, transient rewards, matrix exponentials, and sensitivity analysis. Not registered, and neither is its `DEQuadrature` dependency (installed from a URL, or via the `[sources]` entry on Julia 1.11+); the other dependency, `ZeroOrigin`, is in General. `compat` targets Julia 1.10 (the current LTS); CI runs `min` and `1`, i.e. that lower bound and the latest stable release.
 
 ## Commands
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "NMarkov"
 uuid = "c5cca998-98d3-11ea-1288-bb4300628a81"
-version = "0.4.1"
+version = "0.5.0"
 authors = ["Hiroyuki Okamura"]
 
 [deps]
@@ -14,7 +14,7 @@ ZeroOrigin = "421443cc-9b00-11ea-1646-3bac74f84b0c"
 DEQuadrature = {rev = "master", url = "https://github.com/JuliaReliab/DEQuadrature.jl.git"}
 
 [compat]
-julia = "1.6"
+julia = "1.10"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/README.md
+++ b/README.md
@@ -1,20 +1,23 @@
 # NMarkov
 
-[![CI](https://github.com/okamumu/NMarkov.jl/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/okamumu/NMarkov.jl/actions/workflows/ci.yml)
-[![Codecov](https://codecov.io/gh/okamumu/NMarkov.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/okamumu/NMarkov.jl)
+[![CI](https://github.com/JuliaReliab/NMarkov.jl/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/JuliaReliab/NMarkov.jl/actions/workflows/ci.yml)
+[![Codecov](https://codecov.io/gh/JuliaReliab/NMarkov.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/JuliaReliab/NMarkov.jl)
+
 NMarkov.jl is a package for numerical computation of Markov chains.
+
+Requires Julia 1.10 or later.
 
 ## Installation
 
-This package is not yet registered in the official Julia Registry. Please run the following command to install it.
+Neither this package nor `DEQuadrature` is registered in the official Julia
+Registry, so both are installed from their URLs. `ZeroOrigin`, the other
+dependency, is registered and resolves on its own.
+
 ```julia
 using Pkg
-Pkg.add(PackageSpec(url="https://github.com/JuliaReliab/ZeroOrigin.jl.git"))
 Pkg.add(PackageSpec(url="https://github.com/JuliaReliab/DEQuadrature.jl.git"))
 Pkg.add(PackageSpec(url="https://github.com/JuliaReliab/NMarkov.jl.git"))
 ```
-
-The packages `ZeroOrigin` and `DEQuadrature` are required dependencies of NMarkov.
 
 ## Quick Start
 
@@ -96,26 +99,31 @@ The `SparseMatrix` submodule provides efficient sparse matrix formats optimized 
 - **SparseCSR (Compressed Sparse Row)**: Efficient for row-wise access and matrix-vector products
 - **SparseCSC (Compressed Sparse Column)**: Efficient for column-wise access and recommended for many algorithms
 - **SparseCOO (Coordinate Format)**: Flexible format for constructing sparse matrices; can be converted to CSR/CSC
-- **SparseELL (ELLPACK Format)**: Efficient for matrices with relatively uniform row lengths
+- **SparseELL1 / SparseELL2 (ELLPACK Format)**: Efficient for matrices with relatively uniform row lengths
 - **BlockCOO (Block Coordinate Format)**: For matrices with dense block structure
 
 Each format has different performance characteristics depending on the operation:
 ```julia
+using SparseArrays
 using NMarkov.SparseMatrix
 
 # Convert between formats
-M = sparse(Q)  # Julia's native SparseMatrixCSC
+M = sparse(Q)         # Julia's native SparseMatrixCSC
 csr = SparseCSR(M)    # Convert to CSR format
 csc = SparseCSC(M)    # Convert to CSC format
 coo = SparseCOO(M)    # Convert to COO format
 
 # Use in computations
-piv = stgs(csc)       # Gauss-Seidel with CSC format
-piv = stgs(coo)       # Also works with COO format
+piv, = stgs(csc)      # Gauss-Seidel with CSC format
 y = mexp(csr, x, t)   # Matrix exponential with CSR format
+y = mexp(coo, x, t)   # ... any format, including COO
 ```
 
-For most applications, **CSC format is recommended** as it provides good performance for standard matrix operations and is compatible with the Gauss-Seidel algorithms used in stationary analysis.
+`mexp`, `mexpc`, `tran` and the other transient functions accept every format
+above as well as a dense `Matrix`. The Gauss-Seidel solvers are narrower: **`stgs`,
+`stsengs` and `qstgs` accept only `SparseMatrixCSC` and `SparseCSC`**, so
+**CSC format is the one to reach for** if you need stationary or sensitivity
+analysis on a sparse kernel.
 
 ## Transient Analysis of CTMC
 
@@ -297,11 +305,22 @@ The function returns four values:
 2. **`crwd` (Cumulative Reward)**: The cumulative reward accumulated from time 0 to each time point
    - $\text{crwd}_t = \int_0^t r^T \cdot x(u) \, du$ (total reward up to time $t$)
 
-3. **`y` (State Probability Vectors)**: State probability vector at each time point
-   - $y_t = x \exp(Qt)$ (probability distribution at time $t$)
+3. **`y` (Final State Probability Vector)**: the state probability vector at the
+   **last** time point — a single vector of length $n$, not one per time point
+   - $y = x \exp(Q t_{\text{end}})$
 
-4. **`cy` (Cumulative State Probability)**: Integrated state probability from time 0 to each time point
-   - $\text{cy}_t = \int_0^t x \exp(Qu) \, du$ (cumulative time spent in each state)
+4. **`cy` (Cumulative State Probability)**: the integrated state probability over
+   the **whole** interval — again a single vector of length $n$
+   - $\text{cy} = \int_0^{t_{\text{end}}} x \exp(Qu) \, du$ (total time spent in each state)
+
+Only `irwd` and `crwd` have one entry per time point. If you need the state
+probability vector at every time point, use `mexpc`:
+
+```julia
+probs, cprobs = mexpc(Q, x, ts, transpose=:T)
+# probs[i]  - state probability vector at ts[i]
+# cprobs[i] - cumulative state probability up to ts[i]
+```
 
 Example usage:
 ```julia
@@ -325,8 +344,8 @@ irwd, crwd, y, cy = tran(Q, x, r, ts)
 
 # irwd[i]  - instantaneous reward at ts[i]
 # crwd[i]  - cumulative reward from 0 to ts[i]
-# y[i]     - state probability vector at ts[i]
-# cy[i]    - cumulative time spent in each state up to ts[i]
+# y        - state probability vector at the last time point (one vector)
+# cy       - time spent in each state over the whole interval (one vector)
 ```
 
 This is useful for computing performance metrics such as:
@@ -339,13 +358,15 @@ This is useful for computing performance metrics such as:
 The package provides the function to create some special matrix.
 
 - `eye(n)`: the function to create the n-by-n identity matrix
-- `unif(Q)`: the function to obtain the uniformized transition probability matrix from the infinitesimal generator `Q`;
+- `unif(Q, ufact = 1.01)`: the function to obtain the uniformized transition probability matrix from the infinitesimal generator `Q`;
 
 ```math
-P = I - Q / q
+P = I + Q / q, \quad q = \text{ufact} \cdot \max_i |Q_{ii}|
 ```
 
-where $I$ is the identity matrix and $q$ is the maximum of absolute values of diagonal elements of $Q$. In addition, there are functions to obtain stationary vector and its sensitivity of $P$
+where $I$ is the identity matrix. The factor `ufact` (default `1.01`) keeps $q$
+strictly above $\max_i |Q_{ii}|$, so every entry of $P$ stays positive; `unif`
+returns both $P$ and $q$. In addition, there are functions to obtain stationary vector and its sensitivity of $P$
 
 ```julia
 P, qv = unif(Q)
@@ -493,9 +514,11 @@ end
 # GS-type method
 x, γ, = qstgs(Q, ξ)
 
-# power method
-P, = unif(Q)
-x, γ, = qstpower(P, ξ)
+# power method. qstpower works on the uniformized matrix, so the exit rates
+# must be scaled by q as well, and the eigenvalue it returns is scaled too:
+# γ * qv corresponds to the γ from qstgs.
+P, qv = unif(Q)
+x, γ, = qstpower(P, ξ / qv)
 ```
 
 ### Transient analysis


### PR DESCRIPTION
Follow-up to #15, prompted by "PR と merge で CI が 2 回走るのは無駄では".

## The duplicate run

Half right. `pull_request` tests `refs/pull/N/merge` — the result of merging head
into base — so when base has not moved, the post-merge `push: master` run
re-tests an identical tree. But it is kept, because (a) if base *did* move, the
merge produces a tree the PR run never saw (there are no required status checks
and no "require up to date" setting), and (b) it is the run the README badge
reads.

**The actual waste was elsewhere:** no `concurrency` group, so pushing several
commits to a PR runs each matrix to completion. The last PR did that three times.

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
```

`github.ref` is `refs/pull/N/merge` for a PR and `refs/heads/master` for a push,
so only PR runs are cancelled.

## The bigger problem: the matrix tested no shipping Julia

The matrix was `1.6 / 1.9 / 1.10`. Today **1.10 is the LTS and 1.12 is the
current stable** — so 1.11 and 1.12 were never exercised, while all local
development for #15 happened on 1.12. 1.9 is EOL.

Now `["min", "1"]`: the lower bound from `Project.toml` and the latest stable,
both resolved by `setup-julia`, so the list tracks upstream without editing.
**Two jobs instead of three.**

This required raising `[compat] julia` from `"1.6"` to `"1.10"` (the LTS), which
**drops support for Julia 1.6–1.9** — hence **0.5.0**, not 0.4.2.

## Other CI changes

- `julia-actions/cache@v3` replaces the hand-rolled `actions/cache` step, which
  cached only `~/.julia/artifacts`. Registry fetch and dependency precompile ran
  on every job.
- The `DEQuadrature` URL install is now conditional on `VERSION < v"1.11"`: 1.11+
  resolves it from the `[sources]` entry that earlier versions ignore. **This is
  the riskiest change** — the `[sources]` path had never run in CI.
- Coverage is processed and uploaded from the latest-stable job.
  `julia-runtest` was already collecting it (`coverage` defaults to true) and the
  report was thrown away. `fail_ci_if_error: false`, so a Codecov hiccup cannot
  turn the build red. **Needs a `CODECOV_TOKEN` repository secret to actually
  land** — I cannot set that.

## README: verified against the API by running it

Every code block was executed. Six statements were wrong:

| Was | Is |
|---|---|
| `stgs(coo)` "also works with COO format" | `MethodError`. `stgs`/`stsengs`/`qstgs` take only `SparseMatrixCSC` and `SparseCSC` (the transient functions do take every format) |
| `tran`'s `y`/`cy` are "one state vector per time point" | single vectors — final state, cumulative over the interval. `length(ts)=10` but `length(y)=3` |
| `P = I - Q / q` | `P = I + Q / q`. With the minus sign entries run −0.85 … 1.99 |
| `q = max|Q_ii|` | `q = ufact * max|Q_ii|`, `ufact` defaults to 1.01 |
| Example 4: `qstpower(P, ξ)` | `qstpower(P, ξ / qv)`. Unscaled gives γ·qv = 0.00074 against `qstgs`'s 0.00025 |
| type `SparseELL` | `SparseELL1` / `SparseELL2` |

Plus: both badges pointed at `okamumu/NMarkov.jl`, **which does not exist** (the
repo is `JuliaReliab/NMarkov.jl`), and the `ZeroOrigin` install line is
unnecessary — it is registered in General. `DEQuadrature` and NMarkov itself are
still unregistered, so those URLs stay.

Statements confirmed correct and left alone: the `transpose=:T`/`:N` semantics
(the README was right; the docstrings were the ones that had them backwards, fixed
in #15), `mexp` across all sparse formats, the `do`-block forms of
`mexpmix`/`mexpcmix`, argument order of `stsen`/`stsengs`, `xi = -T * ones(3)`,
`stpower`/`stsenpower`, `eye`, and the generators in Examples 1–4.

## Verification

`test/runtests.jl` passes (2244 assertions) and all seven examples run. The CI
behaviour itself — two jobs, the 1.12 dependency path, cancellation of a
superseded run, coverage only on the latest-stable job — is what this PR's own
checks will show.

## Not done

`master` has branch protection but **no required status checks**, so a red PR can
still be merged. Enabling the two checks would fix that; it is a repository
setting rather than a file, so I left it alone.