### PR TITLE
Prepare 0.5.1 for registration in the JuliaReliab registry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,17 +38,19 @@ jobs:
       - name: Cache Julia depot
         uses: julia-actions/cache@v3
 
-      - name: Install unregistered dependencies
-        # DEQuadrature is not in General. Julia 1.11+ resolves it from the
-        # [sources] entry in Project.toml; earlier versions ignore that section
-        # and need the URL spelled out. ZeroOrigin is in General, so it needs
-        # nothing either way.
+      - name: Add the JuliaReliab registry
+        # DEQuadrature lives here rather than in General (so does NMarkov itself).
+        # Both adds are guarded: julia-actions/cache restores registries between
+        # runs, and adding one that is already present is an error. General is
+        # named explicitly because adding a registry by RegistrySpec on an empty
+        # depot does not pull General in, and Distributions comes from there.
         run: |
-          julia --project=. -e '
+          julia -e '
             using Pkg
-            if VERSION < v"1.11"
-                Pkg.add(PackageSpec(url="https://github.com/JuliaReliab/DEQuadrature.jl.git"))
-            end'
+            names = [r.name for r in Pkg.Registry.reachable_registries()]
+            "General" in names || Pkg.Registry.add("General")
+            "Registry" in names ||
+                Pkg.Registry.add(RegistrySpec(url="https://github.com/JuliaReliab/Registry.git"))'
 
       - name: Build package
         uses: julia-actions/julia-buildpkg@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,31 @@
+# NMarkov 0.5.1
+
+Registered in the JuliaReliab registry, so installation no longer needs URLs:
+
+```julia
+using Pkg
+Pkg.Registry.add(RegistrySpec(url="https://github.com/JuliaReliab/Registry.git"))
+Pkg.add("NMarkov")
+```
+
+- Removed the `[sources]` entry for `DEQuadrature` from `Project.toml`. It is in
+  the same registry, and a registered package's `[sources]` is not honoured when
+  the package is resolved as a dependency, so the entry only added confusion.
+  This also removes the `VERSION < v"1.11"` branch from CI: both jobs now take
+  the same path.
+- Added `[compat]` bounds for `DEQuadrature`, `Distributions` and `ZeroOrigin`.
+  Previously only `julia` was bounded, so the registry recorded no upper bounds
+  for the dependencies at all.
+- CI adds the JuliaReliab registry instead of installing `DEQuadrature` from its
+  URL.
+- `examples/02_transient_analysis.jl` now passes `rmax=1000` to `mexpmix` and
+  `mexpcmix`. Dropping `[sources]` moved `DEQuadrature` from a stale 0.1.4 git
+  checkout to the registered 0.3.0, whose double-exponential quadrature reaches
+  further into the tail: with `bounds = (0, Inf)` the longest interval needs
+  about 830 Poisson terms, over the default `rmax` of 500. Verified against the
+  analytic value `inv(I - Q') * x0` (agreement to 2.3e-8). Documented in the
+  `mexp.jl` module docstring.
+
 # NMarkov 0.5.0
 
 ## Breaking

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project
 
-NMarkov.jl — Julia package for numerical analysis of continuous-time Markov chains (CTMCs): stationary/quasi-stationary distributions, transient rewards, matrix exponentials, and sensitivity analysis. Not registered, and neither is its `DEQuadrature` dependency (installed from a URL, or via the `[sources]` entry on Julia 1.11+); the other dependency, `ZeroOrigin`, is in General. `compat` targets Julia 1.10 (the current LTS); CI runs `min` and `1`, i.e. that lower bound and the latest stable release.
+NMarkov.jl — Julia package for numerical analysis of continuous-time Markov chains (CTMCs): stationary/quasi-stationary distributions, transient rewards, matrix exponentials, and sensitivity analysis. Registered in the JuliaReliab registry (`https://github.com/JuliaReliab/Registry.git`, maintained with LocalRegistry.jl), not in General; so is its `DEQuadrature` dependency. The other dependency, `ZeroOrigin`, is in General. Adding that registry once is all the setup a checkout needs — there is deliberately no `[sources]` entry, since a registered package's `[sources]` is not honoured for consumers. `compat` targets Julia 1.10 (the current LTS); CI runs `min` and `1`, i.e. that lower bound and the latest stable release.
 
 ## Commands
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "NMarkov"
 uuid = "c5cca998-98d3-11ea-1288-bb4300628a81"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Hiroyuki Okamura"]
 
 [deps]
@@ -10,10 +10,10 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 ZeroOrigin = "421443cc-9b00-11ea-1646-3bac74f84b0c"
 
-[sources]
-DEQuadrature = {rev = "master", url = "https://github.com/JuliaReliab/DEQuadrature.jl.git"}
-
 [compat]
+DEQuadrature = "0.3"
+Distributions = "0.25"
+ZeroOrigin = "0.2"
 julia = "1.10"
 
 [extras]

--- a/README.md
+++ b/README.md
@@ -9,15 +9,17 @@ Requires Julia 1.10 or later.
 
 ## Installation
 
-Neither this package nor `DEQuadrature` is registered in the official Julia
-Registry, so both are installed from their URLs. `ZeroOrigin`, the other
-dependency, is registered and resolves on its own.
+NMarkov is registered in the JuliaReliab registry rather than in General. Add
+that registry once, then install as usual:
 
 ```julia
 using Pkg
-Pkg.add(PackageSpec(url="https://github.com/JuliaReliab/DEQuadrature.jl.git"))
-Pkg.add(PackageSpec(url="https://github.com/JuliaReliab/NMarkov.jl.git"))
+Pkg.Registry.add(RegistrySpec(url="https://github.com/JuliaReliab/Registry.git"))
+Pkg.add("NMarkov")
 ```
+
+The registry also provides `DEQuadrature`, so nothing else needs installing by
+hand. The other dependency, `ZeroOrigin`, is in General.
 
 ## Quick Start
 

--- a/examples/02_transient_analysis.jl
+++ b/examples/02_transient_analysis.jl
@@ -42,7 +42,13 @@ println()
 # Compute mixture with exponential distribution
 # y_t = x_0 * int_0^inf exp(Q*u) * f(u) du
 # where f(u) = 1.0 * exp(-1.0*u)
-yt = mexpmix(Q, x0, transpose=:T) do u
+#
+# The default bounds are (0, Inf), and the double-exponential quadrature places
+# its outermost node far out in the tail. The longest interval it asks for here
+# needs about 830 Poisson terms, so the default rmax of 500 is not enough --
+# raise it rather than truncating the integral. (Checked against the analytic
+# value int_0^inf exp(Q'u) x0 e^{-u} du = inv(I - Q') * x0.)
+yt = mexpmix(Q, x0, transpose=:T, rmax=1000) do u
     1.0 * exp(-1.0 * u)
 end
 println("Mixture with exponential distribution:")
@@ -51,7 +57,7 @@ println()
 
 # Compute mixture with cumulative integral
 # y_t, bary_t = x_0 * int_0^inf int_0^u exp(Q*s) ds * f(u) du
-yt, baryt = mexpcmix(Q, x0, transpose=:T) do u
+yt, baryt = mexpcmix(Q, x0, transpose=:T, rmax=1000) do u
     1.0 * exp(-1.0 * u)
 end
 println("Mixture with cumulative integral:")

--- a/src/mexp.jl
+++ b/src/mexp.jl
@@ -29,6 +29,14 @@ Markov chain (DTMC), enabling numerically stable computation via Poisson series 
 - **Reward computation**: Both instantaneous (mexp*) and cumulative (mexpc*) values
 - **Distribution mixing**: Integration with probability distributions via DEQuadrature
 
+## Note on `rmax` for the mixture functions
+
+`mexpmix`/`mexpcmix` default to `bounds = (0, Inf)`, and the double-exponential
+quadrature places its outermost node far into the tail. The longest interval it
+asks for can need well over the default `rmax = 500` Poisson terms — a generator
+with `max|Q_ii|` around 3.5 already needs about 830. Raise `rmax` rather than
+narrowing `bounds`, or the integral is truncated instead of merely coarse.
+
 ## Example
 
 ```julia


### PR DESCRIPTION
Makes `Pkg.add("NMarkov")` work by registering in the JuliaReliab registry
(`https://github.com/JuliaReliab/Registry.git`, where `DEQuadrature` already
lives). Registration itself happens after this merges; this PR is the
preparation.

## `Project.toml`

- **Dropped the `[sources]` entry for `DEQuadrature`.** It is in the same
  registry, and a registered package's `[sources]` is not honoured when the
  package is resolved as a dependency — so shipping it would only mislead.
- **Added `[compat]` bounds** for `DEQuadrature` (`"0.3"`), `Distributions`
  (`"0.25"`) and `ZeroOrigin` (`"0.2"`). Only `julia` was bounded before, so the
  registry would have recorded no dependency bounds at all. (`LinearAlgebra` and
  `SparseArrays` are stdlibs; the registry's existing entries do not bound those
  either.)
- Version 0.5.0 → **0.5.1**. 0.5.0 is on master but was never tagged or
  registered; bumping avoids two different trees claiming the same version.

## CI

The `VERSION < v"1.11"` branch is **gone** — the one awkward bit left over from
#16. Both jobs now take the same path:

```yaml
- name: Add the JuliaReliab registry
  run: |
    julia -e '
      using Pkg
      names = [r.name for r in Pkg.Registry.reachable_registries()]
      "General" in names || Pkg.Registry.add("General")
      "Registry" in names ||
          Pkg.Registry.add(RegistrySpec(url="https://github.com/JuliaReliab/Registry.git"))'
```

Both adds are guarded because `julia-actions/cache` restores registries between
runs and adding an existing one is an error. `General` is named explicitly
because adding a registry by `RegistrySpec` on an empty depot does not pull
General in, and `Distributions` comes from there.

## README

```julia
using Pkg
Pkg.Registry.add(RegistrySpec(url="https://github.com/JuliaReliab/Registry.git"))
Pkg.add("NMarkov")
```

## One behaviour change fell out of this

Dropping `[sources]` moved `DEQuadrature` from a **stale local 0.1.4 git
checkout** to the registered **0.3.0**. 0.3.0's double-exponential quadrature
reaches further into the tail, so with the default `bounds = (0, Inf)` the
longest interval it asks for needs about **830 Poisson terms** — over the default
`rmax = 500`. `examples/02_transient_analysis.jl` therefore now passes
`rmax=1000` to `mexpmix`/`mexpcmix`.

The result is right, not merely bigger: it agrees with the analytic value
`∫₀^∞ exp(Q'u) x₀ e^{-u} du = inv(I - Q') * x₀` to 2.3e-8. Guidance added to the
`mexp.jl` module docstring, since raising `rmax` is the correct response here
rather than narrowing `bounds` (which would truncate the integral).

Worth noting that **CI does not run the examples**, so this only surfaced
locally. Both CI jobs had already been resolving 0.3.0 and passing.

## Verification

- `test/runtests.jl`: 2244 assertions pass with `DEQuadrature` 0.3.0 resolved
  from the registry (`Manifest.toml` regenerated from scratch).
- All seven examples run.
- The registry-based dependency resolution is what this PR's own CI exercises.

After merge: register 0.5.1 with LocalRegistry, tag `v0.5.1`, and cut a GitHub
release. The install instructions above get verified from an empty depot at that
point.