### PR TITLE
README: add General explicitly in the install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,16 @@ that registry once, then install as usual:
 
 ```julia
 using Pkg
+Pkg.Registry.add("General")   # harmless if you already have it; see below
 Pkg.Registry.add(RegistrySpec(url="https://github.com/JuliaReliab/Registry.git"))
 Pkg.add("NMarkov")
 ```
 
 The registry also provides `DEQuadrature`, so nothing else needs installing by
-hand. The other dependency, `ZeroOrigin`, is in General.
+hand. The other dependency, `ZeroOrigin`, comes from General — which is why the
+first line is there: adding a registry by URL into a *fresh* depot skips Julia's
+usual automatic install of General, and the dependency resolution then fails.
+Adding it explicitly is a no-op on an existing installation.
 
 ## Quick Start
 


### PR DESCRIPTION
Verifying the 0.5.1 install instructions from an **empty depot** showed they do
not work:

```
ERROR: cannot find name corresponding to UUID 31c24e10-a181-5473-b8eb-7969acd0382f in a registry
```

That UUID is `Distributions`. Adding a registry by `RegistrySpec(url=...)` into a
fresh depot skips Julia's usual automatic install of General, so `Distributions`
and `ZeroOrigin` cannot be resolved. (The CI workflow already guards against
this — it adds General explicitly — but the README did not.)

`Pkg.Registry.add("General")` is a no-op when General is already present
(checked), so the extra line is safe on an existing installation.

With the fix, in a throwaway depot:

```
gth  = [0.6666666666666666, 0.3333333333333333]
mexp = [0.683262356195858, 0.31673764380414215]
  ZeroOrigin    0.2.0
  DEQuadrature  0.3.0     <- from the JuliaReliab registry
  Distributions 0.25.130
  NMarkov       0.5.1
```

Documentation only; no version bump. The registered 0.5.1 is unaffected.