### PR TITLE
Add dropzero to the mixture functions: stop maxt exploding on the subnormal tail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,48 @@
+# NMarkov 0.5.2
+
+`mexpmix`/`mexpcmix` (and `mexp`/`mexpc` with a `Distribution`) could demand an
+impossible amount of work, or fail with an opaque `InexactError`, for perfectly
+ordinary densities.
+
+The mixture functions build their time grid from the nodes `deint` returns, and
+the Poisson truncation point grows with `qv * maxt`, where `maxt` is the widest
+interval of that grid. The double-exponential transform spaces nodes
+multiplicatively, so one node far out in the tail makes `maxt` as large as that
+node. `deint` keeps every node whose weight is not *exactly* zero, and in the tail
+those weights underflow to subnormals rather than to zero — so the grid ran out to
+`4e15` for `LogNormal(0,1)` and `6.8e128` for `Pareto(1.5,1)`.
+
+- **Added a `dropzero` keyword, default `eps(Tv)`**, passed through to `deint`.
+  Their contribution is of order `1e-299`, so nothing is lost: for `exp(-u)` the
+  result still matches `inv(I - Q') * x0`, while the term count drops from 828 to
+  64. Measured with `max|Q_ii| = 3.5`:
+
+  | density | terms before | terms now |
+  |---|---|---|
+  | `exp(-u)` | 828 | **64** |
+  | `Weibull(2,1)` | 47 | 15 |
+  | `Weibull(0.5,1)` | 835,442 | 1,780 |
+  | `LogNormal(0,1)` | 1.45e16 | 6,737 |
+  | `Pareto(1.5,1)` | `InexactError` | 2.43e10 |
+
+  `exp(-u)`, `Weibull`, `Gamma` now work at the default `rmax`. `Weibull(0.5,1)`
+  and `LogNormal(0,1)` need it raised, which is legitimate — their `maxt` really
+  is larger.
+- **`rightbound` raises `ArgumentError` instead of `InexactError`** when the
+  truncation point does not fit in the index type (`lambda` above about 1e19, or
+  `Inf`). Flooring an out-of-range `Float64` told the caller nothing.
+- **The `rmax` error from the mixture functions now reports `maxt` and `qv`**, so
+  a case that merely needs more terms can be told apart from one whose tail
+  uniformization cannot follow at all. The old message said only "rmax should be
+  changed", which is actively misleading when the required `rmax` is 1e16.
+- Reverted the `rmax=1000` added to `examples/02_transient_analysis.jl` in 0.5.1:
+  that was treating the symptom. The default now suffices.
+- The guidance in the `mexp.jl` module docstring was wrong in the general case
+  ("raise `rmax` rather than narrowing `bounds`") and has been rewritten.
+
+Existing results are unchanged: the hardcoded reference values in
+`test/test_mix.jl` still agree to 1e-8.
+
 # NMarkov 0.5.1
 
 Registered in the JuliaReliab registry, so installation no longer needs URLs:

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "NMarkov"
 uuid = "c5cca998-98d3-11ea-1288-bb4300628a81"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["Hiroyuki Okamura"]
 
 [deps]

--- a/examples/02_transient_analysis.jl
+++ b/examples/02_transient_analysis.jl
@@ -43,12 +43,8 @@ println()
 # y_t = x_0 * int_0^inf exp(Q*u) * f(u) du
 # where f(u) = 1.0 * exp(-1.0*u)
 #
-# The default bounds are (0, Inf), and the double-exponential quadrature places
-# its outermost node far out in the tail. The longest interval it asks for here
-# needs about 830 Poisson terms, so the default rmax of 500 is not enough --
-# raise it rather than truncating the integral. (Checked against the analytic
-# value int_0^inf exp(Q'u) x0 e^{-u} du = inv(I - Q') * x0.)
-yt = mexpmix(Q, x0, transpose=:T, rmax=1000) do u
+# The analytic value is int_0^inf exp(Q'u) x0 e^{-u} du = inv(I - Q') * x0.
+yt = mexpmix(Q, x0, transpose=:T) do u
     1.0 * exp(-1.0 * u)
 end
 println("Mixture with exponential distribution:")
@@ -57,7 +53,7 @@ println()
 
 # Compute mixture with cumulative integral
 # y_t, bary_t = x_0 * int_0^inf int_0^u exp(Q*s) ds * f(u) du
-yt, baryt = mexpcmix(Q, x0, transpose=:T, rmax=1000) do u
+yt, baryt = mexpcmix(Q, x0, transpose=:T) do u
     1.0 * exp(-1.0 * u)
 end
 println("Mixture with cumulative integral:")

--- a/src/mexp.jl
+++ b/src/mexp.jl
@@ -29,13 +29,28 @@ Markov chain (DTMC), enabling numerically stable computation via Poisson series 
 - **Reward computation**: Both instantaneous (mexp*) and cumulative (mexpc*) values
 - **Distribution mixing**: Integration with probability distributions via DEQuadrature
 
-## Note on `rmax` for the mixture functions
+## Note on `dropzero` for the mixture functions
 
-`mexpmix`/`mexpcmix` default to `bounds = (0, Inf)`, and the double-exponential
-quadrature places its outermost node far into the tail. The longest interval it
-asks for can need well over the default `rmax = 500` Poisson terms — a generator
-with `max|Q_ii|` around 3.5 already needs about 830. Raise `rmax` rather than
-narrowing `bounds`, or the integral is truncated instead of merely coarse.
+`mexpmix`/`mexpcmix` build their time grid from the nodes `deint` returns, and the
+Poisson truncation point grows with `qv * maxt`, where `maxt` is the widest
+interval of that grid. The double-exponential transform spaces nodes
+multiplicatively, so a node far out in the tail makes `maxt` as large as the node
+itself.
+
+`deint` keeps every node whose weight is not exactly zero, and in the tail those
+weights underflow to subnormals rather than to zero — for `LogNormal(0,1)` the
+grid then reaches `4e15` and the truncation point `1.5e16`, which is not a
+computation anyone can run. `dropzero` (default `eps(Tv)`) discards those nodes.
+Their contribution is of order `1e-299`, so the integral is unchanged: for
+`exp(-u)` the value matches `inv(I - Q') * x0` either way, while the term count
+drops from 828 to 64.
+
+So when the term count exceeds `rmax`, check `maxt` in the error message before
+reaching for a larger `rmax`. A moderate `maxt` just needs more terms; an enormous
+one means the integrand has a tail uniformization cannot follow over an unbounded
+range, and the fix is finite `bounds` or a larger `dropzero`. A genuinely
+heavy-tailed density such as `Pareto(1.5, 1)` still needs bounded integration
+even with the default `dropzero`.
 
 ## Example
 
@@ -123,6 +138,29 @@ x = [1.0; 0.0]
 prob_t2 = mexp(Q, x, 2.0)  # Probability after 2 time units
 ```
 """
+
+"""
+    _checkmixrmax(name, right, rmax, maxt, qv)
+
+Check the Poisson truncation point of a mixture computation against `rmax`, and
+report enough to tell the two causes apart.
+
+`right` grows with `qv * maxt`, where `maxt` is the widest interval of the
+quadrature grid. A moderate `maxt` that merely needs more terms is a different
+situation from a `maxt` of 1e15, which means the grid reaches into a tail that
+uniformization cannot follow at any affordable cost — raising `rmax` there asks
+for a buffer of that many elements and a loop of that many iterations.
+"""
+function _checkmixrmax(name::String, right, rmax, maxt, qv)
+    right <= rmax || throw(ArgumentError(
+        "$name: the quadrature needs $right Poisson terms, over rmax = $rmax. " *
+        "The widest interval of the grid is maxt = $maxt at uniformization rate " *
+        "qv = $qv, and the term count grows with their product. If maxt is " *
+        "moderate, raise rmax. If it is enormous, the integrand has a tail that " *
+        "uniformization cannot follow over an unbounded range: pass finite " *
+        "`bounds`, or raise `dropzero` to discard the negligible tail nodes."))
+    nothing
+end
 
 # Single public method: every argument is converted to the element type of Q and
 # the work is then done by _mexp. Keeping the conversion and the kernel in
@@ -602,14 +640,15 @@ mixed2 = mexpmix(t -> pdf(dist, t), Q, x; bounds=(0, 20))
 
 @inbounds function mexpmix(f::Any, Q::AbstractMatrix{Tv}, x::ArrayT;
     bounds=(Tv(0.0), Tv(Inf)), transpose::Symbol=:N,
-    ufact::Tv=Tv(1.01), eps::Tv=Tv(1.0e-8), rmax=500) where {Tv,ArrayT<:AbstractArray{Tv}}
+    ufact::Tv=Tv(1.01), eps::Tv=Tv(1.0e-8), dropzero::Tv=Base.eps(Tv),
+    rmax=500) where {Tv,ArrayT<:AbstractArray{Tv}}
     m, n = size(Q)
     @assert m == n
-    de = deint(f, bounds[1], bounds[2])
+    de = deint(f, bounds[1], bounds[2]; dropzero=dropzero)
     dt, maxt = itime(de.x)
     P, qv = unif(Q, ufact)
     right = rightbound(qv*maxt, eps)
-    @assert right <= rmax "Time interval is too large. rmax should be changed: right = $right (rmax: $rmax)."
+    _checkmixrmax("mexpmix", right, rmax, maxt, qv)
     prob = Vector{Tv}(undef, right+1)
 
     y0 = copy(x)
@@ -638,8 +677,10 @@ end
 
 function mexp(Q::AbstractMatrix{Tv}, x::ArrayT, dist::UnivariateDistribution;
     bounds=(minimum(dist), maximum(dist)), transpose::Symbol=:N,
-    ufact::Tv=Tv(1.01), eps::Tv=Tv(1.0e-8), rmax=500) where {Tv,ArrayT<:AbstractArray{Tv}}
-    mexpmix(Q, x, bounds=bounds, transpose=transpose, ufact=ufact, eps=eps, rmax=rmax) do x
+    ufact::Tv=Tv(1.01), eps::Tv=Tv(1.0e-8), dropzero::Tv=Base.eps(Tv),
+    rmax=500) where {Tv,ArrayT<:AbstractArray{Tv}}
+    mexpmix(Q, x, bounds=bounds, transpose=transpose, ufact=ufact, eps=eps,
+        dropzero=dropzero, rmax=rmax) do x
         pdf(dist, x)
     end
 end
@@ -741,14 +782,15 @@ state_mix, reward_mix = mexpcmix(t -> 0.5*exp(-0.5*t), Q, x; bounds=(0, 30))
 
 @inbounds function mexpcmix(f::Any, Q::AbstractMatrix{Tv}, x::ArrayT;
     bounds=(Tv(0.0), Tv(Inf)), transpose::Symbol=:N,
-    ufact::Tv=Tv(1.01), eps::Tv=Tv(1.0e-8), rmax=500) where {Tv,ArrayT<:AbstractArray{Tv}}
+    ufact::Tv=Tv(1.01), eps::Tv=Tv(1.0e-8), dropzero::Tv=Base.eps(Tv),
+    rmax=500) where {Tv,ArrayT<:AbstractArray{Tv}}
     m, n = size(Q)
     @assert m == n
-    de = deint(f, bounds[1], bounds[2])
+    de = deint(f, bounds[1], bounds[2]; dropzero=dropzero)
     dt, maxt = itime(de.x)
     P, qv = unif(Q, ufact)
     right = rightbound(qv*maxt, eps) + 1
-    @assert right <= rmax "Time interval is too large. rmax should be changed: right = $right (rmax: $rmax)."
+    _checkmixrmax("mexpcmix", right, rmax, maxt, qv)
     prob = Vector{Tv}(undef, right+1)
     cprob = Vector{Tv}(undef, right+1)
 
@@ -783,8 +825,10 @@ end
 
 function mexpc(Q::AbstractMatrix{Tv}, x::ArrayT, dist::UnivariateDistribution;
     bounds = (minimum(dist), maximum(dist)), transpose::Symbol=:N,
-    ufact::Tv=Tv(1.01), eps::Tv=Tv(1.0e-8), rmax=500) where {Tv,ArrayT<:AbstractArray{Tv}}
-    mexpcmix(Q, x, bounds=bounds, transpose=transpose, ufact=ufact, eps=eps, rmax=rmax) do x
+    ufact::Tv=Tv(1.01), eps::Tv=Tv(1.0e-8), dropzero::Tv=Base.eps(Tv),
+    rmax=500) where {Tv,ArrayT<:AbstractArray{Tv}}
+    mexpcmix(Q, x, bounds=bounds, transpose=transpose, ufact=ufact, eps=eps,
+        dropzero=dropzero, rmax=rmax) do x
         pdf(dist, x)
     end
 end

--- a/src/poisson.jl
+++ b/src/poisson.jl
@@ -262,6 +262,14 @@ function rightbound(::Type{Ti}, lambda::Tv, q::Tv = Tv(1.0e-8))::Ti where {Tv, T
         right
     else
         z = cquantile(Normal(), q)
-        right = floor(Ti, (z + sqrt(4 * lambda - 1))^2 / 4 + 1)
+        r = (z + sqrt(4 * lambda - 1))^2 / 4 + 1
+        # Check before flooring: `floor(Ti, r)` throws an InexactError for a
+        # non-finite or out-of-range r, which tells the caller nothing about why.
+        # lambda that large means the requested time interval cannot be handled
+        # by uniformization at all, so say so.
+        isfinite(r) && r <= typemax(Ti) || throw(ArgumentError(
+            "the Poisson mean $lambda is too large for uniformization: the " *
+            "truncation point would be about $r terms, which does not fit in $Ti"))
+        right = floor(Ti, r)
     end
 end

--- a/test/test_regression.jl
+++ b/test/test_regression.jl
@@ -3,6 +3,7 @@
 
 using LinearAlgebra: I, exp
 using SparseArrays: sparse
+using Distributions: Weibull, LogNormal, Gamma, Pareto, pdf
 
 @testset "regression" begin
 
@@ -560,6 +561,95 @@ end
     for A in (sparse(Qfull), SparseCSC(Qfull))
         @test_throws ArgumentError qstgs(A, xifull)
     end
+end
+
+## --- The mixture functions build their time grid from deint's nodes, and the
+##     Poisson truncation point grows with qv * maxt where maxt is the widest
+##     interval of that grid. deint keeps every node whose weight is not exactly
+##     zero, and in the tail those weights underflow to subnormals rather than to
+##     zero, so maxt used to blow up: 4e15 for LogNormal, 6.8e128 for Pareto.
+##     `dropzero` (default eps(Tv)) discards them, at no cost in accuracy.
+@testset "mexpmix tail nodes" begin
+    Q = [
+        -1.0 1.0 0.0;
+        0.0 -0.1 0.1;
+        3.0 0.5 -3.5
+    ]
+    x0 = Float64[1, 0, 0]
+
+    # These all used to need rmax far above the default; exp(-u) needed 828
+    # against a default of 500, purely because of the subnormal tail.
+    for (name, f) in (("exp", u -> exp(-u)),
+                      ("Weibull(2,1)", u -> pdf(Weibull(2.0, 1.0), u)),
+                      ("Gamma(0.3,1)", u -> pdf(Gamma(0.3, 1.0), u)))
+        y = mexpmix(Q, x0, transpose=:T) do u
+            f(u)
+        end
+        @test all(isfinite.(y))
+        yc, byc = mexpcmix(Q, x0, transpose=:T) do u
+            f(u)
+        end
+        @test all(isfinite.(yc)) && all(isfinite.(byc))
+    end
+
+    # Accuracy is untouched: int_0^inf exp(Q'u) x0 e^{-u} du = inv(I - Q') * x0.
+    exact = (Matrix(1.0I, 3, 3) - Q') \ x0
+    y = mexpmix(Q, x0, transpose=:T) do u
+        exp(-u)
+    end
+    @test maximum(abs.(y - exact)) < 1.0e-7
+
+    # ... and dropping the tail nodes does not move the answer: keeping them
+    # (dropzero = 0, which needs rmax = 828) gives the same vector.
+    ykeep = mexpmix(Q, x0, transpose=:T, dropzero=0.0, rmax=1000) do u
+        exp(-u)
+    end
+    @test y ≈ ykeep rtol = 1.0e-10
+
+    # A moderate maxt that simply needs more terms is reported as such, and works
+    # once rmax is raised.
+    for (name, dist, terms) in (("Weibull(0.5,1)", Weibull(0.5, 1.0), 1780),
+                                ("LogNormal(0,1)", LogNormal(0.0, 1.0), 6737))
+        err = nothing
+        try
+            mexpmix(Q, x0, transpose=:T) do u
+                pdf(dist, u)
+            end
+        catch e
+            err = e
+        end
+        @test err isa ArgumentError
+        # the message must expose maxt, so the caller can tell "needs more terms"
+        # from "the tail is hopeless"
+        @test occursin("maxt", sprint(showerror, err))
+        yd = mexpmix(Q, x0, transpose=:T, rmax=10 * terms) do u
+            pdf(dist, u)
+        end
+        @test all(isfinite.(yd))
+        @test sum(yd) ≈ 1.0 rtol = 1.0e-6
+    end
+
+    # Keeping the subnormal tail is what blew maxt up; it must be reported, not
+    # turned into a 100-PiB allocation.
+    @test_throws ArgumentError mexpmix(Q, x0, transpose=:T, dropzero=0.0) do u
+        pdf(LogNormal(0.0, 1.0), u)
+    end
+
+    # A genuinely heavy tail cannot be followed over an unbounded range even with
+    # the default dropzero. It must fail loudly rather than with an InexactError
+    # from flooring an out-of-range Float64.
+    @test_throws ArgumentError mexpmix(Q, x0, transpose=:T) do u
+        pdf(Pareto(1.5, 1.0), u)
+    end
+    # bounding the range makes it computable
+    yp = mexpmix(Q, x0, transpose=:T, bounds=(1.0, 100.0)) do u
+        pdf(Pareto(1.5, 1.0), u)
+    end
+    @test all(isfinite.(yp))
+
+    # rightbound must not overflow into an InexactError either.
+    @test_throws ArgumentError rightbound(1.0e19, 1.0e-8)
+    @test_throws ArgumentError rightbound(Inf, 1.0e-8)
 end
 
 ## --- trans() must reject an unknown symbol rather than returning nothing.


### PR DESCRIPTION
Prompted by the same failure seen in the phfit package: `deint`'s default
`dropzero = 0` keeps tail nodes whose weights have underflowed to *subnormals*
rather than to zero, and the time grid built from those nodes explodes.

**NMarkov has the identical structure.** `src/mexp.jl` (the only two `deint` call
sites) does

```julia
de = deint(f, bounds[1], bounds[2])   # dropzero not passed -> default 0
dt, maxt = itime(de.x)                # absolute times -> interval widths
right = rightbound(qv*maxt, eps)      # buffer length == loop count
```

The double-exponential transform spaces nodes multiplicatively, so one node far
out in the tail makes `maxt` as large as that node itself.

## Measured, with `max|Q_ii| = 3.5` (`qv = 3.535`), `bounds = (0, Inf)`

| density | maxt / terms before | maxt / terms now | integral |
|---|---|---|---|
| `exp(-u)` | 191 / **828** | 7.67 / **64** | 1.0 both |
| `Weibull(2,1)` | 4.68 / 47 | 0.656 / 15 | 1.0 |
| `Weibull(0.5,1)` | 2.35e5 / **835,442** | 439 / 1,780 | 1.0 |
| `LogNormal(0,1)` | 4.11e15 / **1.45e16** | 1,780 / 6,737 | 1.0 |
| `Pareto(1.5,1)` | 6.78e128 / **`InexactError`** | 6.86e9 / 2.43e10 | 1.001 |
| `Gamma(0.3,1)` | 191 / 828 | 5.96 / 55 | 1.0 |

Three distinct failure modes were reachable from the public API:
`Weibull(0.5,1)` and `LogNormal(0,1)` raised `AssertionError`, and
`Pareto(1.5,1)` raised **`InexactError: Int64(2.395e129)`** from flooring an
out-of-range Float64 inside `rightbound`.

## Changes

- **`dropzero` keyword, default `eps(Tv)`**, on `mexpmix`/`mexpcmix` and threaded
  through the `mexp`/`mexpc` `Distribution` methods. The discarded weights are of
  order `1e-299`, so accuracy is untouched — `exp(-u)` still matches
  `inv(I - Q') * x0`, and the test asserts the answer is unchanged against a run
  with `dropzero = 0`. `exp`/`Weibull`/`Gamma` now work at the **default** `rmax`.
- **`rightbound` raises `ArgumentError`** rather than `InexactError` when the
  truncation point does not fit the index type (`lambda` above ~1e19, or `Inf`).
- **The `rmax` error now reports `maxt` and `qv`**, so "needs more terms" is
  distinguishable from "this tail cannot be followed". The old text said only
  "rmax should be changed" — actively misleading when the required `rmax` is 1e16.

## This corrects two mistakes I made in 0.5.1

- The `rmax=1000` I added to `examples/02_transient_analysis.jl` was treating a
  symptom: those 828 terms *were* the subnormal tail, not a real requirement. The
  default suffices now, so it is reverted.
- The module docstring said to "raise `rmax` rather than narrowing `bounds`". For
  `LogNormal(0,1)` that means an `rmax` of 1.45e16 — roughly 116 PiB and a loop
  that never ends. Rewritten around `dropzero` and the heavy-tail case.

`Pareto(1.5,1)` still needs finite `bounds` even with the default `dropzero`; that
is inherent, since the cost is proportional to `qv * maxt`. The test pins the
clear error plus the bounded-range call succeeding.

Not a DEQuadrature bug: returning every node with a nonzero weight is the right
behaviour for `deint`. Trimming the tail is the responsibility of the caller that
uses those nodes as a time series.

## Verification

- `test/test_mix.jl`'s hardcoded reference values still agree to 1e-8 — the main
  risk, checked first.
- Full suite: 2265 assertions (was 2244).
- All seven examples run, 02 with the default `rmax`.