### PR TITLE
docs: bring CLAUDE.md in line with the current state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,10 +9,19 @@ NMarkov.jl — Julia package for numerical analysis of continuous-time Markov ch
 ## Commands
 
 ```bash
-julia --project=. -e 'using Pkg; Pkg.instantiate()'   # setup (DEQuadrature comes from [sources] git rev)
+# One-time: the JuliaReliab registry provides DEQuadrature (and NMarkov itself).
+# Without it, instantiate cannot resolve DEQuadrature — there is no [sources] entry.
+julia -e 'using Pkg;
+  names = [r.name for r in Pkg.Registry.reachable_registries()]
+  "General" in names || Pkg.Registry.add("General")
+  "Registry" in names ||
+      Pkg.Registry.add(RegistrySpec(url="https://github.com/JuliaReliab/Registry.git"))'
+
+julia --project=. -e 'using Pkg; Pkg.instantiate()'   # setup
 julia --project=. -e 'using Pkg; Pkg.test()'          # full test suite
 julia --project=. test/runtests.jl                    # same, faster (no sandbox)
-julia --project=. examples/02_transient_analysis.jl    # run an example
+julia --project=. examples/02_transient_analysis.jl   # run an example
+for f in examples/0*.jl; do julia --project=. $f; done  # CI does NOT run these
 ```
 
 To run a single test file, run `runtests.jl` with the other `include` lines skipped, or:
@@ -21,15 +30,28 @@ To run a single test file, run `runtests.jl` with the other `include` lines skip
 julia --project=. -e 'using NMarkov, Test; include("test/test_mexp.jl")'
 ```
 
-There is no linter or formatter configured.
+There is no linter or formatter configured. `Manifest.toml` is untracked, so
+regenerating it is always safe.
+
+**Releasing.** Bump `version` in `Project.toml`, merge to `master`, then from a
+`master` checkout: register with LocalRegistry (`register("<path>";
+registry="Registry")` — it commits to `~/.julia/registries/Registry` and pushes to
+`JuliaReliab/Registry`), tag `vX.Y.Z`, and cut a GitHub release titled
+`NMarkov X.Y.Z`. Register before releasing, so a release never points at an
+unregistered version. Verify from an empty depot:
+`JULIA_DEPOT_PATH=$(mktemp -d) julia -e '...Pkg.add("NMarkov")...'`.
 
 ## Architecture
 
 Everything is one module, `NMarkov`, with a nested submodule `NMarkov.SparseMatrix`. Include order in `src/NMarkov.jl` is load-bearing: `SparseMatrix` → `utils.jl` → analysis files → `poisson.jl` → `mexp.jl` → `transient_analysis.jl` → `conv.jl`.
 
-**Uniformization is the backbone.** Nearly every transient computation goes through `unif(Q, ufact) -> (P, qv)` (`src/utils.jl`), which builds the DTMC `P = I + Q/qv`, then weights powers of `P` by Poisson pmf values from `poipmf`/`cpoipmf`/`rightbound` (`src/poisson.jl`). `rightbound(qt, eps)` decides the truncation point; callers assert it against `rmax` (default 500) and error with "Time interval is too large" rather than silently degrading. When touching `mexp.jl`, `transient_analysis.jl`, or `conv.jl`, keep this pattern — do not substitute a dense `exp(Q*t)`.
+**Uniformization is the backbone.** Nearly every transient computation goes through `unif(Q, ufact) -> (P, qv)` (`src/utils.jl`), which builds the DTMC `P = I + Q/qv`, then weights powers of `P` by Poisson pmf values from `poipmf`/`cpoipmf`/`rightbound` (`src/poisson.jl`). `rightbound(qt, eps)` decides the truncation point, which is simultaneously a buffer length and a loop count; callers check it against `rmax` (default 500) and raise rather than silently degrading. When touching `mexp.jl`, `transient_analysis.jl`, or `conv.jl`, keep this pattern — do not substitute a dense `exp(Q*t)`.
 
-**Regression tests.** `test/test_regression.jl` pins the bugs found in the 0.4.0 review; each testset names the behaviour it guards (absorbing-state uniformization, Poisson truncation order, time-vector validation, element-type genericity, the `AbstractMatrix` contract). Treat a failure there as a re-introduced bug, not a stale expectation.
+**`dropzero` for the mixture functions.** `mexpmix`/`mexpcmix` build their time grid from the nodes `DEQuadrature.deint` returns, and the truncation point grows with `qv * maxt` where `maxt` is the *widest interval* of that grid. The DE transform spaces nodes multiplicatively, so one node far out in the tail makes `maxt` as large as that node. `deint` keeps every node whose weight is not exactly zero, and tail weights underflow to *subnormals* rather than to zero — with `dropzero = 0` the grid reached `4e15` for `LogNormal(0,1)` and `6.8e128` for `Pareto(1.5,1)`. Hence the `dropzero` keyword, default `eps(Tv)`; the discarded contributions are of order `1e-299`, so the integral is unchanged (for `exp(-u)` it still matches `inv(I - Q') * x0`, while the term count drops 828 → 64).
+
+When a term count exceeds `rmax`, **read `maxt` from the error before reaching for a larger `rmax`** — `_checkmixrmax` (`mexp.jl`) prints it for exactly this reason. A moderate `maxt` just needs more terms; an enormous one means the tail cannot be followed over an unbounded range, and raising `rmax` would ask for a buffer of that many elements. A genuinely heavy-tailed density needs finite `bounds` regardless of `dropzero`. This is not a DEQuadrature bug: returning every nonzero-weight node is right for `deint`; trimming the tail is the caller's job because the caller uses those nodes as a time series.
+
+**Tests.** `test/runtests.jl` includes one file per area (`test_sparsematrix`, `test_stationary`, `test_poisson`, `test_matrix`, `test_mexp`, `test_mix`, `test_conv`, `test_transient`) plus `test_regression.jl`. That last one pins the bugs found in the 0.4.0 review and after; each testset names the behaviour it guards (absorbing-state uniformization, the `z`/`H` summation ranges in `conv`, time-vector validation, `poipmf` domain validation, Gauss-Seidel diagonal preconditions, element-type genericity, the `AbstractMatrix` contract, mixture tail nodes). Treat a failure there as a re-introduced bug, not a stale expectation. The seven `examples/*.jl` are **not** run by CI — check them by hand after touching `mexp.jl`/`transient_analysis.jl`, since they exercise paths the tests do not (the `dropzero` bug surfaced only there).
 
 **Layered API files:**
 - `stationary_analysis.jl` — `gth`/`gth!` (direct GTH elimination), `stgs` (Gauss–Seidel via `gsstep!`), `stpower`, `stguess`.
@@ -55,3 +77,59 @@ Everything is one module, `NMarkov`, with a nested submodule `NMarkov.SparseMatr
 
 - Every `@origin` block here is also `@inbounds`, so a logical index outside the declared domain is an *unchecked* out-of-bounds access — a segfault, or a silent buffer under/overflow that still returns plausible numbers. Validate the domain once before entering the block; `_checkpoirange` (`poisson.jl`) and `_checkconvrange` (`conv.jl`) are the existing guards, and any new `@origin` kernel needs the equivalent. `poipmf!` is the cautionary case: it seeds at `prob[floor(lambda)]`, so the domain must contain the mode.
 - Only the arrays listed in the macro call are rewritten, and a listed *matrix* would share one origin across all dimensions. The matrices in these kernels (`H`, `y0`, `y1`, `cy`) are deliberately not listed.
+
+## Session log
+
+### 2026-07-29 / 30 — full code review of 0.4.0, then packaging (0.4.1 → 0.5.2)
+
+Started as "review this codebase", grew into four releases. All merged to `master`
+via PRs #15–#19; 0.5.1 and 0.5.2 are registered, tagged and released.
+
+**Correctness fixes (0.4.1).** The one defect on a well-trodden path: `unif`
+returned a non-stochastic `P` for a *sparse* generator whose diagonal was not fully
+stored (an absorbing state's zero diagonal is dropped by dense→sparse conversion,
+and `spdiag`'s `setindex!` discarded the write with only a warning) — so every
+downstream `mexp`/`mexpc`/`tran`/`conv` result was wrong. Fixed with `adddiag`.
+Also: `convunifstep!` normalised `z` by a weight covering a wider range than it
+summed; `rightbound` looped forever below Float64; unsorted/negative time vectors
+returned `NaN`; `stguess`/`gth`/the Gauss-Seidel solvers returned `NaN` on
+absorbing states; `poipmf!`/`cpoipmf!` wrote outside their buffer (segfault, or
+silent heap corruption returning plausible numbers); a `Base.iszero(::Float64)`
+definition was pirating `iszero` for every `Float64` in the session. Plus the
+`Float32`/`Float16`/`Int`/`BigFloat` paths (infinite recursion, `Float64`-only
+sparse BLAS, ambiguous scalar `*`/`/`), the CSR `gsstep!` `UndefVarError`, and the
+`AbstractMatrix` contract on `AbstractSparseM` (`length` was `nnz`).
+
+**Packaging (0.5.0 → 0.5.2).** Julia compat raised 1.6 → 1.10 (LTS); CI matrix
+`1.6/1.9/1.10` → `["min","1"]` (it had been testing an EOL version and *no*
+shipping Julia); `concurrency` added so superseded PR runs are cancelled;
+`julia-actions/cache@v3`; coverage wired up; registered in the JuliaReliab registry
+so `Pkg.add("NMarkov")` works; `[sources]` dropped; required status checks
+(`Julia min`, `Julia 1`, `strict=true`) enabled on `master`. 0.5.2 fixed the
+`dropzero` blow-up described above.
+
+**Three mistakes I made, for calibration.** (1) Reported `conv.jl`'s `H` as buggy;
+it matches the paper bit-for-bit and I had only changed `z`. (2) "Verified" that the
+old `z` was more accurate — using a matrix whose rows did not sum to zero, so
+`unif`'s `P` was not stochastic and the whole comparison was vacuous. Always test
+CTMC code with a real generator. (3) `adddiag` initially converted to COO just to
+*test* the diagonal, making `unif` 2–4× slower; caught only because the
+before/after benchmark was actually run.
+
+**Verification habits that paid off.** Benchmarking before/after caught (3).
+Running the examples caught the `dropzero` blow-up and three broken example
+scripts. Executing every README snippet caught six wrong statements (including
+`tran`'s return values and the sign of the uniformization formula). Installing from
+an empty depot caught that the README's install instructions did not work.
+
+**Pending / notes for next session.**
+- No open work items. `refactor` and `master` are level.
+- `CODECOV_TOKEN` is **not** set as a repository secret, so the coverage upload
+  fails silently (`fail_ci_if_error: false`) and the Codecov badge stays stale.
+  Adding it is a repository-settings task.
+- `mexp`/`mexpc`/`tran` still use `@assert` for the `rmax` check with the old
+  "Time interval is too large" text; only the mixture functions were converted to
+  `ArgumentError` with `maxt` reported. Worth unifying if that message ever
+  misleads someone.
+- `test/test_matrix.jl`'s `unif1`/`unif2`/`unif3` only `println` — zero assertions.
+  The real coverage is in `test_regression.jl`.


### PR DESCRIPTION
Documentation only.

Four things in `CLAUDE.md` had gone stale or were missing:

- **Setup was wrong.** It said DEQuadrature "comes from `[sources]` git rev", but
  `[sources]` was removed in 0.5.1. A fresh checkout now needs the JuliaReliab
  registry added before `Pkg.instantiate()` can resolve it. The snippet in the file
  was run as-is to confirm it works.
- **No release procedure** was recorded. Added it, including the ordering (register
  before cutting the release, so a release never points at an unregistered
  version) and the empty-depot verification.
- **The `dropzero` convention was undocumented** — the whole reason for it, and why
  the `rmax` error prints `maxt`, is that a large term count has two causes needing
  opposite fixes. Without this, the natural move is to raise `rmax`, which is
  exactly wrong when `maxt` is 4e15.
- **Tests section** now lists the per-area files and what `test_regression.jl`
  guards, and flags that **CI does not run `examples/`** — which is how the
  `dropzero` blow-up went unnoticed until it was checked by hand.

Also appended a session log for the 0.4.1–0.5.2 work: what changed, the three
mistakes I made along the way (reporting `conv.jl`'s `H` as buggy when it matches
the paper; "verifying" with a matrix whose rows did not sum to zero, making the
comparison vacuous; `adddiag` converting to COO merely to test the diagonal and
slowing `unif` 2–4×), the verification habits that caught them, and the open items:

- `CODECOV_TOKEN` is not set, so coverage upload fails silently and the badge is stale.
- `mexp`/`mexpc`/`tran` still use the old `@assert` "Time interval is too large"
  text; only the mixture functions report `maxt`.
- `test_matrix.jl`'s `unif1`/`unif2`/`unif3` have zero assertions.